### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "export"
   ],
   "description": "images and JSON annotations",
-  "docker_image": "supervisely/import-export:6.73.560",
+  "docker_image": "supervisely/import-export:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "export"
   ],
   "description": "images and JSON annotations",
-  "docker_image": "supervisely/import-export:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.486
+supervisely==6.73.564

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/supervisely/supervisely.git@tag-value-date
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-git+https://github.com/supervisely/supervisely.git@tag-value-date
-


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
